### PR TITLE
Disable UseShellExecute and bring the window to the front in case Ctrl + Click is used

### DIFF
--- a/BrowserSelect/Form1.cs
+++ b/BrowserSelect/Form1.cs
@@ -19,6 +19,7 @@ namespace BrowserSelect
         public Form1()
         {
             InitializeComponent();
+            MaximizeBox = false;
         }
 
         public void updateBrowsers()
@@ -289,12 +290,15 @@ namespace BrowserSelect
             var top = wa.Height / 2 + wa.Top - Height / 2;
 
             this.Location = new Point(left, top);
-            this.Activate();
-            // Bring BrowserSelect up front if link is clicked inside UWP apps, notably Windows Terminal
-            this.WindowState = FormWindowState.Normal;
-            this.BringToFront();
+
+            
+            // Borrowed from https://stackoverflow.com/a/5853542
+            // Get the window to the front
             this.TopMost = true;
-            this.Focus();
+            this.TopMost = false;
+
+            // "Steal" the focus
+            this.Activate();            
         }
 
         private void btn_help_Click(object sender, EventArgs e)

--- a/BrowserSelect/Form1.cs
+++ b/BrowserSelect/Form1.cs
@@ -253,7 +253,12 @@ namespace BrowserSelect
             }
             else
             {
-                Process.Start(b.exec, Program.Args2Str(args));
+                ProcessStartInfo startInfo = new ProcessStartInfo(b.exec);
+                // Clicking MS Edge takes more than 4 seconds to load, even with an existing window
+                // Disabling UseShellExecute to create the process directly from the browser executable file
+                startInfo.UseShellExecute = false;
+                startInfo.Arguments = Program.Args2Str(args);
+                Process.Start(startInfo);
             }
             Application.Exit();
         }
@@ -285,6 +290,11 @@ namespace BrowserSelect
 
             this.Location = new Point(left, top);
             this.Activate();
+            // Bring BrowserSelect up front if link is clicked inside UWP apps, notably Windows Terminal
+            this.WindowState = FormWindowState.Normal;
+            this.BringToFront();
+            this.TopMost = true;
+            this.Focus();
         }
 
         private void btn_help_Click(object sender, EventArgs e)


### PR DESCRIPTION
- Improvement: Use `ProcessStartInfo` with `UseShellExcute` set to `false` in starting new browser processes. This mechanism bypasses OS shell and starts the browser directly from the executable file.
- Improvement: If Ctrl + Click is used to follow links and Ctrl is not released, BrowserSelect should be visible.