### PR TITLE
Improve perf and fix permission denied errors with latest Chrome releases

### DIFF
--- a/BrowserSelect/Browser.cs
+++ b/BrowserSelect/Browser.cs
@@ -177,10 +177,11 @@ namespace BrowserSelect
         private static List<string> FindChromeProfiles(string ChromeUserDataDir, string IconFilename)
         {
             List<string> Profiles = new List<string>();
-            var ProfileDirs = Directory.GetFiles(ChromeUserDataDir, IconFilename, SearchOption.AllDirectories).Select(Path.GetDirectoryName);
-            foreach (var Profile in ProfileDirs)
+            var TopLevelDirs = Directory.GetDirectories(ChromeUserDataDir);
+            foreach (var Dir in TopLevelDirs)
             {
-                Profiles.Add(Profile.Substring(ChromeUserDataDir.Length + 1));
+                var BaseName = Dir.Substring(ChromeUserDataDir.Length + 1);
+                if (File.Exists(Dir + "\\" + IconFilename)) { Profiles.Add(BaseName); }
             }
             return Profiles;
         }

--- a/BrowserSelect/ForegroundAgent.cs
+++ b/BrowserSelect/ForegroundAgent.cs
@@ -34,7 +34,7 @@ namespace BrowserSelect
         /// also gives said window focus (setForegroundWindow)
         /// </summary>
         /// <param name="hwnd">hWnd of window to be restored</param>
-        public static void RestoreWindow(int hwnd)
+        public static void RestoreWindow(long hwnd)
         {
 
             var hWnd = new IntPtr(hwnd);


### PR DESCRIPTION
The latest Chrome release includes some features that disallows programs to read certain files, like:

```
System.UnauthorizedAccessException: Access to the path 'C:\Users\quark\AppData\Local\Google\Chrome\User Data\OnDeviceHeadSuggestModel\20231010.253971461.12' is denied.
   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.FileSystemEnumerableIterator`1.AddSearchableDirsToStack(SearchData localSearchData)
   at System.IO.FileSystemEnumerableIterator`1.MoveNext()
   at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
   at System.IO.Directory.GetFiles(String path, String searchPattern, SearchOption searchOption)
   at BrowserSelect.BrowserFinder.FindChromeProfiles(String ChromeUserDataDir)
   at BrowserSelect.BrowserFinder.find(Boolean update)
   at BrowserSelect.Form1.updateBrowsers()
   at BrowserSelect.Form1.Form1_Load(Object sender, EventArgs e)
   at System.Windows.Forms.Form.OnLoad(EventArgs e)
   at System.Windows.Forms.Form.OnCreateControl()
   at System.Windows.Forms.Control.CreateControl(Boolean fIgnoreVisible)
   at System.Windows.Forms.Control.CreateControl()
   at System.Windows.Forms.Control.WmShowWindow(Message& m)
   at System.Windows.Forms.Control.WndProc(Message& m)
   at System.Windows.Forms.Form.WmShowWindow(Message& m)
   at System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)
```

Fix it by only visiting top-level directories to detect profiles. This should also improve performance.